### PR TITLE
MacOS客户端教程补充及mkworld编译失败Bug的修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ PS C:\Windows\system32>
 ## 4.3 安卓客户端配置
 [Zerotier 非官方安卓客户端发布：支持自建 Moon 节点 - V2EX](https://www.v2ex.com/t/768628)
 
+## 4.4 MacOS 客户端配置
+步骤如下：
+
+1. 进入 `/Library/Application\ Support/ZeroTier/One/` 目录，并替换目录下的 `planet` 文件
+2. 重启 ZeroTier-One：`cat /Library/Application\ Support/ZeroTier/One/zerotier-one.pid | sudo xargs kill`
+3. 加入网络 `zerotier-cli join` 网络 `id`
+4. 管理后台同意加入请求
+5. `zerotier-cli peers` 可以看到` planet` 角色
+
 # 参考链接
 [zerotier-虚拟局域网详解](https://www.glimmer.ltd/2021/3299983056/)
 

--- a/init.sh
+++ b/init.sh
@@ -19,7 +19,11 @@ dpkg-reconfigure --frontend noninteractive tzdata
 rm -rf /var/lib/apt/lists/*
 
 apt update
-apt install git python3 npm make curl -y
+apt install git python3 npm make curl wget -y
+
+mkdir /usr/include/nlohmann/
+cd /usr/include/nlohmann/ && wget https://github.com/nlohmann/json/releases/download/v3.10.5/json.hpp
+
 npm config set registry http://registry.npm.taobao.org && npm install -g node-gyp
 curl -s https://install.zerotier.com | bash
 cd /opt && git clone -v http://gh-proxy.markxu.vip/https://github.com/key-networks/ztncui.git


### PR DESCRIPTION
教程部分：补充了MacOS的简易脚本，仅需要5步即可让MacOS的ZeroTier客户端支持自定义Planet
Bug Fix部分：先前直接Build时，会出现：`../../osdep/OSUtils.hpp:46:10: fatal error: nlohmann/json.hpp: No such file or directory` 的问题，造成最后并没有编译出正确的planet的问题；因此补充了在 `/usr/include` 下直接下载 `nlohmann/json.hpp` 的代码，此外，直接使用 wget 往 `/usr/include` 下塞东西确实不够优雅，但是不知道为啥 `apt install nlohmann-json-dev` 是 missing 的，考虑到这块后续也不会有啥变化，就是用了这种比较简单直接的方式。