### PR TITLE
Fix deploy.sh bug; When entering the internal IP manually, docker still uses the public IP when starting up.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -218,6 +218,8 @@ function update(){
      -p ${ZT_PORT}:${ZT_PORT}/udp \
      -p ${API_PORT}:${API_PORT}\
      -p ${FILE_PORT}:${FILE_PORT} \
+     -e IP_ADDR4=${ipv4} \
+     -e IP_ADDR6=${ipv6} \
      -e ZT_PORT=${ZT_PORT} \
      -e API_PORT=${API_PORT} \
      -e FILE_SERVER_PORT=${FILE_PORT} \


### PR DESCRIPTION
Fixes a bug in the deploy.sh script where the manually entered internal IPv4 and IPv6 addresses were not properly mounted in the container startup. This caused the entrypoint.sh script to treat IP_ADDR4 and IP_ADDR6 as non-existent, resulting in the retrieval of the public IP. The issue is resolved by adding the following environment variables to the container startup command:

-e IP_ADDR4=${ipv4}
-e IP_ADDR6=${ipv6}

The updated startup command is as follows:

```bash
docker run -d --name myztplanet
  -p ${ZT_PORT}:${ZT_PORT}
  -p ${ZT_PORT}:${ZT_PORT}/udp
  -p ${API_PORT}:${API_PORT}
  -p ${FILE_PORT}:${FILE_PORT}
  -e IP_ADDR4=${ipv4}
  -e IP_ADDR6=${ipv6}
  -e ZT_PORT=${ZT_PORT}
  -e API_PORT=${API_PORT}
  -e FILE_SERVER_PORT=${FILE_PORT}
  -v $(pwd)/data/zerotier/dist:/app/dist
  -v $(pwd)/data/zerotier/ztncui:/app/ztncui
  -v $(pwd)/data/zerotier/one:/var/lib/zerotier-one
  -v $(pwd)/data/zerotier/config:/app/config
  xubiaolin/zerotier-planet:latest
```

Please review and merge this fix. Thank you!