### PR TITLE
统一路径

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ services:
       - ./data/zerotier/dist:/app/dist
       - ./data/zerotier/ztncui:/app/ztncui
       - ./data/zerotier/one:/var/lib/zerotier-one
-      - ./data/config:/app/config
+      - ./data/zerotier/config:/app/config
     restart: unless-stopped
 
 ```

--- a/deploy.sh
+++ b/deploy.sh
@@ -230,7 +230,7 @@ uninstall() {
 #         -v $(pwd)/data/zerotier/dist:/app/dist \
 #         -v $(pwd)/data/zerotier/ztncui:/app/ztncui \
 #         -v $(pwd)/data/zerotier/one:/var/lib/zerotier-one \
-#         -v $(pwd)/data/config:/app/config \
+#         -v $(pwd)/data/zerotier/config:/app/config \
 #         --restart unless-stopped \
 #         xubiaolin/zerotier-planet:latest
 # }


### PR DESCRIPTION
docker run 与 docker compose 启动，配置文件路径不一致，导致通过deploy.sh启动后，再重新使用docker compose up 方式启动出错